### PR TITLE
Modify bot_comment.md

### DIFF
--- a/.github/workflows/bot_comment.md
+++ b/.github/workflows/bot_comment.md
@@ -8,6 +8,7 @@
 - [ ] **textlintを参考に、可能な限り執筆・修正：**
 最初はReviewerを追加せず、このDraft Pull Requestで執筆・修正を続けてください。可能な限りtextlintが指摘を行います。
 漢字や送り仮名に対する微妙な指摘については、[電子情報通信学会の資料（1ページ）](https://www.ieice.org/jpn/shiori/pdf/furoku_d.pdf)や[常用漢字一覧表 - 文化庁](https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kakuki/14/pdf/jyouyou_kanjihyou.pdf)を参考にしてください。
+修正した指摘や無視した指摘については、Resolve conversationボタンを押しておくと良いです。
 Review commentの数が100に近づくとページの表示が重くなります。適宜Draft Pull RequestをCloseし、別のDraft Pull Requestで作業を続けてください。
 - [ ] **参考文献のタイトルに含まれる固有名詞を`{}`で囲う：**
 Bibtexでは、タイトルの文字が自動的に大文字や小文字に変換されます。固有名詞をそのままの文字で残すため、それらを波括弧で囲んでください。textlintからの指摘は行われないので注意してください。

--- a/.github/workflows/bot_comment.md
+++ b/.github/workflows/bot_comment.md
@@ -9,7 +9,7 @@
 最初はReviewerを追加せず、このDraft Pull Requestで執筆・修正を続けてください。可能な限りtextlintが指摘を行います。
 漢字や送り仮名に対する微妙な指摘については、[電子情報通信学会の資料（1ページ）](https://www.ieice.org/jpn/shiori/pdf/furoku_d.pdf)や[常用漢字一覧表 - 文化庁](https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kakuki/14/pdf/jyouyou_kanjihyou.pdf)を参考にしてください。
 Review commentの数が100に近づくとページの表示が重くなります。適宜Draft Pull RequestをCloseし、別のDraft Pull Requestで作業を続けてください。
-- [ ] **参考文献のタイトルに含まれる固有名詞を`{}`で囲う**
+- [ ] **参考文献のタイトルに含まれる固有名詞を`{}`で囲う：**
 Bibtexでは、タイトルの文字が自動的に大文字や小文字に変換されます。固有名詞をそのままの文字で残すため、それらを波括弧で囲んでください。textlintからの指摘は行われないので注意してください。
 （例）`title={... {MySQL}}`
 - [ ] **`.github/workflows/textlint.yml`と`.github/workflows/comment-open-pull-request.yml`を削除し、commitをpush：**

--- a/.github/workflows/bot_comment.md
+++ b/.github/workflows/bot_comment.md
@@ -9,6 +9,9 @@
 最初はReviewerを追加せず、このDraft Pull Requestで執筆・修正を続けてください。可能な限りtextlintが指摘を行います。
 漢字や送り仮名に対する微妙な指摘については、[電子情報通信学会の資料（1ページ）](https://www.ieice.org/jpn/shiori/pdf/furoku_d.pdf)や[常用漢字一覧表 - 文化庁](https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kakuki/14/pdf/jyouyou_kanjihyou.pdf)を参考にしてください。
 Review commentの数が100に近づくとページの表示が重くなります。適宜Draft Pull RequestをCloseし、別のDraft Pull Requestで作業を続けてください。
+- [ ] **参考文献のタイトルに含まれる固有名詞を`{}`で囲う**
+Bibtexでは、タイトルの文字が自動的に大文字や小文字に変換されます。固有名詞をそのままの文字で残すため、それらを波括弧で囲んでください。textlintからの指摘は行われないので注意してください。
+（例）`title={... {MySQL}}`
 - [ ] **`.github/workflows/textlint.yml`と`.github/workflows/comment-open-pull-request.yml`を削除し、commitをpush：**
 修正が完了し、Reviewerに添削をお願いできる状況になったら、上記ファイルを削除してcommitをpushしてください。以降のcommitに対してはtextlintによる指摘が行われなくなります。
 - [ ] **このDraft Pull RequestをClose**

--- a/.github/workflows/comment-open-pull-request.yml
+++ b/.github/workflows/comment-open-pull-request.yml
@@ -2,7 +2,7 @@ name: Comment for Opened Pull Request
 
 on:
   pull_request:
-#    types: [opened]
+    types: [opened]
 
 jobs:
   comment:

--- a/.github/workflows/comment-open-pull-request.yml
+++ b/.github/workflows/comment-open-pull-request.yml
@@ -2,7 +2,7 @@ name: Comment for Opened Pull Request
 
 on:
   pull_request:
-    types: [opened]
+#    types: [opened]
 
 jobs:
   comment:


### PR DESCRIPTION
Resolved #8 

変更点は以下の通りです．
- Resolve conversationボタンを押しておくことについての記述を追加
- 参考文献のタイトルの固有名詞を波括弧で囲むことについての記述とチェックリストへの追加

例のコメントアウトはそのままです．