### PR TITLE
fix update.bash

### DIFF
--- a/update.bash
+++ b/update.bash
@@ -47,7 +47,7 @@ rm ${latest_file}
 
   pushd ${unzip_dir} > /dev/null
   # TODO: Clarify exclude file and directory.
-  for file in $(find . -type d \( -path './.github/ISSUE_TEMPLATE' -o -path './dir' \) -prune -false -o -type f -not -name 'README.md' -not -name '**.tex' -not -name 'update.bash');
+  for file in $(find . -type d \( -path './.github/ISSUE_TEMPLATE' -o -path './dir' \) -prune -false -o -type f -not -name 'README.md' -not -name '**.tex' -not -name 'update.bash' -not -name 'dict_check.py');
   do
     diff -N ${file} ../${file} > /dev/null
     if [ $? -ne 0 ] ;


### PR DESCRIPTION
update.bash の実行時，辞書の衝突検出ファイルをダウンロードしないようにしました．
以下のコマンドでダウンロードしないことを確認しました．
` curl -sSf https://raw.githubusercontent.com/dbgroup-nagoya-u/paper-lintrules/fix_update.bash/update.bash | bash`
Resolve #168 