### PR TITLE
Delete max-kanji-continuous-len

### DIFF
--- a/lintrules/textlint/textlint.json
+++ b/lintrules/textlint/textlint.json
@@ -5,6 +5,7 @@
   "filters": {},
   "rules": {
     "preset-ja-technical-writing": {
+      "max-kanji-continuous-len": false,
       "sentence-length": false,
       "max-ten": {
         "max": 2,


### PR DESCRIPTION
多分デフォルトでtrueなのでfalseに修正